### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
       install_requires=[
           'pandas',
       ],
-      packages=find_packages(exclude=("tests", "test.*", "*test*")),
+      packages=find_packages(where='src', exclude=("tests", "test.*", "*test*")),
 )

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,5 @@ setup(
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
-      install_requires=[
-          'pandas',
-      ],
-      packages=find_packages(exclude=("tests", "test.*", "*test*")),
+      packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
-      packages=find_packages(where="src"),
+      packages=["src/ucimlrepo"]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setup(
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
-      packages=["src/ucimlrepo"]
+      package_dir={'': 'src'},
+      packages=find_packages(where='src')
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,4 @@ setup(name='ucimlrepo',
       author_email='philtr928@example.com',
       license='MIT',
       packages=['ucimlrpeo'],
-      install_requires=[
-          'pandas',
-      ],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
-setup(name='ucimlrepo',
-      version='0.1',
+setup(
+      name='ucimlrepo',
+      version='0.0.1',
       description='A Python interface to import datasets from the UCI Machine Learning Repository',
       url='https://github.com/uci-ml-repo/ucimlrepo',
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
-      packages=['ucimlrepo'],
-      zip_safe=False)
+      packages=find_packages(exclude=("tests", "test.*", "*test*")),
+)

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
-      packages=find_packages(),
+      packages=find_packages(where="src"),
 )

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,8 @@ setup(
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
+      install_requires=[
+          'pandas',
+      ],
       packages=find_packages(exclude=("tests", "test.*", "*test*")),
 )

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup
 setup(name='ucimlrepo',
       version='0.1',
       description='A Python interface to import datasets from the UCI Machine Learning Repository',
-      url='',
+      url='https://github.com/uci-ml-repo/ucimlrepo',
       author='Philip Truong',
       author_email='philtr928@example.com',
       license='MIT',
-      packages=['ucimlrpeo'],
+      packages=['ucimlrepo'],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
       install_requires=[
           'pandas',
       ],
-      packages=find_packages(where='src', exclude=("tests", "test.*", "*test*")),
+      packages=find_packages(exclude=("tests", "test.*", "*test*")),
 )


### PR DESCRIPTION
Installing the package as: 

`!pip install git+https://github.com/uci-ml-repo/ucimlrepo.git` was not working due to some errors including the name of the package to be included and the fact that the package was not being found.

After some experimentation and reading documentation about `setuptools` in Python, this configuration seems to be working and making the `ucimlrepo` available under the python directory.